### PR TITLE
Changed visibility of properties

### DIFF
--- a/src/Clarifai.php
+++ b/src/Clarifai.php
@@ -30,21 +30,21 @@ class Clarifai
      *
      * @var Client $client
      */
-    protected $client;
+    private $client;
 
     /**
      * The Clarifai url
      *
      * @var string $url
      */
-    protected $url = 'https://api.clarifai.com';
+    private $url = 'https://api.clarifai.com';
 
     /**
      * The version of the Clarifai API
      *
      * @var string $version
      */
-    protected $version = 'v2';
+    private $version = 'v2';
 
     /**
      * Clarifai Client ID

--- a/src/ClarifaiApiException.php
+++ b/src/ClarifaiApiException.php
@@ -29,7 +29,12 @@ class ClarifaiApiException extends Exception
         // Construct message from JSON if required.
         if (preg_match('/^[\[\{]\"/', $message)) {
             $messageObject = json_decode($message);
-            $message = $messageObject->status . ': ' . $messageObject->title . ' - ' . $messageObject->detail;
+            $message = sprintf(
+                '%s: %s - %s',
+                $messageObject->status,
+                $messageObject->title,
+                $messageObject->detail
+            );
             if (!empty($messageObject->errors)) {
                 $message .= ' ' . serialize($messageObject->errors);
             }

--- a/src/ClarifaiConcept.php
+++ b/src/ClarifaiConcept.php
@@ -23,49 +23,49 @@ class ClarifaiConcept
      *
      * @var string $conceptId
      */
-    protected $conceptId;
+    private $conceptId;
 
     /**
      * The name of the concept
      *
      * @var string $conceptName
      */
-    protected $conceptName;
+    private $conceptName;
 
     /**
      * The date the concept was created at
      *
      * @var string $createdAt
      */
-    protected $createdAt;
+    private $createdAt;
 
     /**
      * The app ID
      *
      * @var string $appId
      */
-    protected $appId;
+    private $appId;
 
     /**
      * The value
      *
      * @var string|null $value
      */
-    protected $value = null;
+    private $value = null;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor

--- a/src/ClarifaiConcepts.php
+++ b/src/ClarifaiConcepts.php
@@ -23,21 +23,21 @@ class ClarifaiConcepts
      *
      * @var array $concepts
      */
-    protected $concepts;
+    private $concepts;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor

--- a/src/ClarifaiInput.php
+++ b/src/ClarifaiInput.php
@@ -24,56 +24,56 @@ class ClarifaiInput extends Clarifai
      *
      * @var string $inputId
      */
-    protected $inputId;
+    private $inputId;
 
     /**
      * The date the input was created at
      *
      * @var string $createdAt
      */
-    protected $createdAt;
+    private $createdAt;
 
     /**
      * The image URL
      *
      * @var string $imageUrl
      */
-    protected $imageUrl;
+    private $imageUrl;
 
     /**
      * The concepts associated with this input
      *
      * @var ClarifaiConcepts $concepts
      */
-    protected $concepts;
+    private $concepts;
 
     /**
      * The input score
      *
      * @var float $score
      */
-    protected $score;
+    private $score;
 
     /**
      * The metadata
      *
      * @var array $metaData
      */
-    protected $metaData;
+    private $metaData;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor

--- a/src/ClarifaiInputs.php
+++ b/src/ClarifaiInputs.php
@@ -23,21 +23,21 @@ class ClarifaiInputs
      *
      * @var array $inputs
      */
-    protected $inputs;
+    private $inputs;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor

--- a/src/ClarifaiModel.php
+++ b/src/ClarifaiModel.php
@@ -24,56 +24,56 @@ class ClarifaiModel extends Clarifai
      *
      * @var string $modelId
      */
-    protected $modelId;
+    private $modelId;
 
     /**
      * The name of the model
      *
      * @var string $modelName
      */
-    protected $modelName;
+    private $modelName;
 
     /**
      * The date the model was created at
      *
      * @var string $createdAt
      */
-    protected $createdAt;
+    private $createdAt;
 
     /**
      * The app ID
      *
      * @var string $appId
      */
-    protected $appId;
+    private $appId;
 
     /**
      * The output info
      *
      * @var string $outputInfo
      */
-    protected $outputInfo;
+    private $outputInfo;
 
     /**
      * The model version
      *
      * @var string $modelVersion
      */
-    protected $modelVersion;
+    private $modelVersion;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor

--- a/src/ClarifaiModels.php
+++ b/src/ClarifaiModels.php
@@ -23,21 +23,21 @@ class ClarifaiModels
      *
      * @var array $models
      */
-    protected $models;
+    private $models;
 
     /**
      * The config
      *
      * @var object $config
      */
-    protected $config;
+    private $config;
 
     /**
      * The raw data
      *
      * @var array $rawData
      */
-    protected $rawData;
+    private $rawData;
 
     /**
      * Constructor


### PR DESCRIPTION
Hey Darryn!
I've made changes to object properties visibility. They are not heirs of any other classes, so it's better to keep their properties private.
Also i've changed how exception message is generated, concatenation changed to `sprintf` the string is more readable now.
What do you think?
